### PR TITLE
 Fixes formatting errors in README_EN.md

### DIFF
--- a/README_EN.md
+++ b/README_EN.md
@@ -18,41 +18,41 @@ Allows you to generate a meander (one- and two-stroke);
 Atmega328p, Atmega2560
 
 ### Documentation
-There is [extended documentation] to the library (https://alexgyver.ru/gyvertimers/)
+There is [extended documentation](https://alexgyver.ru/gyvertimers/) to the library 
 
 ## Content
-- [installation] (# Install)
-- [initialization] (#init)
-- [use] (#usage)
-- [Example] (# Example)
-- [versions] (#varsions)
-- [bugs and feedback] (#fedback)
+- [Installation](#install)
+- [Initialization](#init)
+- [Usage](#usage)
+- [Example](#example)
+- [Versions](#versions)
+- [Bugs and feedback](#feedback)
 
 <a id="install"> </a>
 ## Installation
-- The library can be found by the name ** gyvertimers ** and installed through the library manager in:
+- The library can be found by the name **gyvertimers** and installed through the library manager in:
     - Arduino ide
     - Arduino ide v2
     - Platformio
-- [download the library] (https://github.com/gyverlibs/gyvertimers/archive/refs/heads/main.zip) .Zip archive for manual installation:
+- [download the library](https://github.com/gyverlibs/gyvertimers/archive/refs/heads/main.zip) .Zip archive for manual installation:
     - unpack and put in * C: \ Program Files (X86) \ Arduino \ Libraries * (Windows X64)
     - unpack and put in * C: \ Program Files \ Arduino \ Libraries * (Windows X32)
     - unpack and put in *documents/arduino/libraries/ *
     - (Arduino id) Automatic installation from. Zip: * sketch/connect the library/add .Zip library ... * and specify downloaded archive
-- Read more detailed instructions for installing libraries [here] (https://alexgyver.ru/arduino-first/#%D0%A3%D1%81%D1%82%D0%B0%BD%D0%BE%BE%BE%BED0%B2%D0%BA%D0%B0_%D0%B1%D0%B8%D0%B1%D0%BB%D0%B8%D0%BE%D1%82%D0%B5%D0%BA)
+- Read more detailed instructions for installing libraries [here](https://alexgyver.ru/arduino-first/#%D0%A3%D1%81%D1%82%D0%B0%BD%D0%BE%BE%BE%BED0%B2%D0%BA%D0%B0_%D0%B1%D0%B8%D0%B1%D0%BB%D0%B8%D0%BE%D1%82%D0%B5%D0%BA)
 ### Update
 - I recommend always updating the library: errors and bugs are corrected in the new versions, as well as optimization and new features are added
 - through the IDE library manager: find the library how to install and click "update"
-- Manually: ** remove the folder with the old version **, and then put a new one in its place.“Replacement” cannot be done: sometimes in new versions, files that remain when replacing are deleted and can lead to errors!
+- Manually: **remove the folder with the old version**, and then put a new one in its place. “Replacement” cannot be done: sometimes in new versions, files that remain when replacing are deleted and can lead to errors!
 
 
 <a id="init"> </a>
-## initialization
+## Initialization
 No
 
 <a id="usage"> </a>
 ## Usage
-`` `CPP
+```CPP
 Methods for Timer0, Timer1, Timer2 ...
 uint32_t setperiod (period);// Installation of the period in microseconds and starting the timer.Returns the real period (accuracy is limited by the timer resolution).
 uint32_t setfrequency (frequency);// Frequency installation in Hertz and the timer launch.Returns the real frequency (accuracy is limited by the timer resolution).
@@ -132,12 +132,12 @@ Timer5 |16 bit |0.24 Hz - 1 MHz |4 200 000 .. 1 μs |Channel_a |46 |PL3 |
         ||||Channel_c |44 |PL5 |
 ------------------------------------------------------------------------------------------
 */
-`` `
+```
 
 <a id="EXAMPLE"> </a>
 ## Example
 The rest of the examples look at ** Examples **!
-`` `CPP
+```CPP
 // Demonstration of all functions of the library
 
 #include <gyvertimers.h>
@@ -198,10 +198,10 @@ ISR (Timer0_A) {
 VOID loop () {
 
 }
-`` `
+```
 
 <a id="versions"> </a>
-## versions
+## Versions
 - V1.1 - Fixed error in the calculation of periods
 - V1.2 - The code is divided into h and CPP
 - v1.3 - a slight bug is corrected
@@ -214,16 +214,16 @@ VOID loop () {
 - V1.10 - added flag of Ready
 
 <a id="feedback"> </a>
-## bugs and feedback
-Create ** Issue ** when you find the bugs, and better immediately write to the mail [alex@alexgyver.ru] (mailto: alex@alexgyver.ru)
-The library is open for refinement and your ** pull Request ** 'ow!
+## Bugs and feedback
+Create an **issue** when you find bugs, and better immediately write to the mail [alex@alexgyver.ru](mailto:alex@alexgyver.ru)
+The library is open for refinement and your **pull requests**.
 
 
 When reporting about bugs or incorrect work of the library, it is necessary to indicate:
 - The version of the library
 - What is MK used
 - SDK version (for ESP)
-- version of Arduino ide
-- whether the built -in examples work correctly, in which the functions and designs are used, leading to a bug in your code
-- What code is loaded, what slaveOta was expected from him and how he works in reality
-- Ideally, attach the minimum code in which the bug is observed.Not a canvas of a thousand lines, but a minimum code
+- Version of Arduino IDE
+- Whether the built-in examples work correctly, in which the functions and designs are used, leading to a bug in your code
+- What code is loaded, what was expected, and how it works in reality
+- Ideally, attach the minimum code in which the bug is observed. Not a thousand lines, but a minimum code.

--- a/README_EN.md
+++ b/README_EN.md
@@ -35,10 +35,10 @@ There is [extended documentation](https://alexgyver.ru/gyvertimers/) to the libr
     - Arduino ide v2
     - Platformio
 - [download the library](https://github.com/gyverlibs/gyvertimers/archive/refs/heads/main.zip) .Zip archive for manual installation:
-    - unpack and put in * C: \ Program Files (X86) \ Arduino \ Libraries * (Windows X64)
-    - unpack and put in * C: \ Program Files \ Arduino \ Libraries * (Windows X32)
-    - unpack and put in *documents/arduino/libraries/ *
-    - (Arduino id) Automatic installation from. Zip: * sketch/connect the library/add .Zip library ... * and specify downloaded archive
+    - unpack and put in *C:\Program Files (X86)\Arduino\Libraries* (Windows X64)
+    - unpack and put in *C:\Program Files\Arduino\Libraries* (Windows X32)
+    - unpack and put in *documents/arduino/libraries/* (Mac)
+    - (Arduino IDE) Automatic installation from ZIP: *Sketch > Include library > Add .ZIP library...* and specify downloaded archive
 - Read more detailed instructions for installing libraries [here](https://alexgyver.ru/arduino-first/#%D0%A3%D1%81%D1%82%D0%B0%BD%D0%BE%BE%BE%BED0%B2%D0%BA%D0%B0_%D0%B1%D0%B8%D0%B1%D0%BB%D0%B8%D0%BE%D1%82%D0%B5%D0%BA)
 ### Update
 - I recommend always updating the library: errors and bugs are corrected in the new versions, as well as optimization and new features are added


### PR DESCRIPTION
Some headers, code blocks, formatting, and links were broken during the automated translation to English, which made the content difficult to read. These issues are now fixed.